### PR TITLE
Refactor test codes.

### DIFF
--- a/apps/wsb-pilot/src/cmd/command.rs
+++ b/apps/wsb-pilot/src/cmd/command.rs
@@ -1,0 +1,49 @@
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub struct CommandRunner {
+    program: String,
+    current_dir: PathBuf,
+    args: Vec<String>,
+}
+
+impl CommandRunner {
+    pub fn new<A: Into<String>>(program: A) -> Self {
+        Self {
+            program: program.into(),
+            current_dir: PathBuf::new(),
+            args: vec![],
+        }
+    }
+
+    pub fn current_dir<A: AsRef<Path>>(mut self, dir: A) -> Self {
+        self.current_dir = dir.as_ref().to_path_buf();
+        self
+    }
+
+    pub fn arg<A: AsRef<OsStr>>(mut self, arg: A) -> Self {
+        self.args.push(arg.as_ref().to_string_lossy().to_string());
+        self
+    }
+
+    pub fn args<I, S>(self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut xs = self;
+        for arg in args {
+            xs = xs.arg(arg);
+        }
+        xs
+    }
+
+    pub fn output(self) -> io::Result<Output> {
+        Command::new(self.program)
+            .current_dir(self.current_dir)
+            .args(self.args)
+            .output()
+    }
+}

--- a/apps/wsb-pilot/src/cmd/mod.rs
+++ b/apps/wsb-pilot/src/cmd/mod.rs
@@ -1,2 +1,5 @@
-mod command;
-pub use command::CommandRunner;
+mod runner;
+pub use runner::CommandRunner;
+
+mod output;
+pub use output::CommandOutput;

--- a/apps/wsb-pilot/src/cmd/mod.rs
+++ b/apps/wsb-pilot/src/cmd/mod.rs
@@ -1,0 +1,2 @@
+mod command;
+pub use command::CommandRunner;

--- a/apps/wsb-pilot/src/cmd/output.rs
+++ b/apps/wsb-pilot/src/cmd/output.rs
@@ -1,0 +1,42 @@
+use std::process::Output;
+
+pub struct CommandOutput {
+    output: Output,
+}
+
+impl CommandOutput {
+    pub fn new(output: Output) -> Self {
+        CommandOutput { output }
+    }
+
+    pub fn stdout(&self) -> &[u8] {
+        &self.output.stdout
+    }
+
+    pub fn stderr(&self) -> &[u8] {
+        &self.output.stderr
+    }
+
+    pub fn status_code(&self) -> i32 {
+        self.output
+            .status
+            .code()
+            .expect("Process terminated by signal")
+    }
+
+    pub fn dump(&self) {
+        let to_string = |vec| String::from_utf8_lossy(vec).to_string();
+        println!("{}", to_string(&self.stdout()));
+
+        let e = to_string(&self.stderr());
+        if e.len() > 0 {
+            println!("stderr: {}", e);
+        }
+    }
+
+    pub fn dump_if_failed(&self) {
+        if !self.output.status.success() {
+            self.dump();
+        }
+    }
+}

--- a/apps/wsb-pilot/src/cmd/output.rs
+++ b/apps/wsb-pilot/src/cmd/output.rs
@@ -1,3 +1,5 @@
+use crate::PilotResult;
+use serde_json::Value;
 use std::process::Output;
 
 pub struct CommandOutput {
@@ -22,6 +24,11 @@ impl CommandOutput {
             .status
             .code()
             .expect("Process terminated by signal")
+    }
+
+    pub fn to_json(&self) -> PilotResult<Value> {
+        let value: Value = serde_json::from_slice(self.stdout())?;
+        Ok(value)
     }
 
     pub fn dump(&self) {

--- a/apps/wsb-pilot/src/cmd/output.rs
+++ b/apps/wsb-pilot/src/cmd/output.rs
@@ -31,6 +31,10 @@ impl CommandOutput {
         Ok(value)
     }
 
+    pub fn to_stdout_string(&self) -> String {
+        String::from_utf8_lossy(self.stdout()).to_string()
+    }
+
     pub fn dump(&self) {
         let to_string = |vec| String::from_utf8_lossy(vec).to_string();
         println!("{}", to_string(&self.stdout()));

--- a/apps/wsb-pilot/src/cmd/output.rs
+++ b/apps/wsb-pilot/src/cmd/output.rs
@@ -26,12 +26,12 @@ impl CommandOutput {
             .expect("Process terminated by signal")
     }
 
-    pub fn to_json(&self) -> PilotResult<Value> {
+    pub fn stdout_to_json(&self) -> PilotResult<Value> {
         let value: Value = serde_json::from_slice(self.stdout())?;
         Ok(value)
     }
 
-    pub fn to_stdout_string(&self) -> String {
+    pub fn stdout_to_string(&self) -> String {
         String::from_utf8_lossy(self.stdout()).to_string()
     }
 

--- a/apps/wsb-pilot/src/cmd/runner.rs
+++ b/apps/wsb-pilot/src/cmd/runner.rs
@@ -47,6 +47,9 @@ impl CommandRunner {
             .args(self.args)
             .output()?;
 
-        Ok(CommandOutput::new(output))
+        let reified = CommandOutput::new(output);
+        reified.dump();
+
+        Ok(reified)
     }
 }

--- a/apps/wsb-pilot/src/cmd/runner.rs
+++ b/apps/wsb-pilot/src/cmd/runner.rs
@@ -1,7 +1,8 @@
+use crate::cmd::CommandOutput;
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::Command;
 
 pub struct CommandRunner {
     program: String,
@@ -40,10 +41,12 @@ impl CommandRunner {
         xs
     }
 
-    pub fn output(self) -> io::Result<Output> {
-        Command::new(self.program)
+    pub fn output(self) -> io::Result<CommandOutput> {
+        let output = Command::new(self.program)
             .current_dir(self.current_dir)
             .args(self.args)
-            .output()
+            .output()?;
+
+        Ok(CommandOutput::new(output))
     }
 }

--- a/apps/wsb-pilot/src/cmd/runner.rs
+++ b/apps/wsb-pilot/src/cmd/runner.rs
@@ -41,15 +41,23 @@ impl CommandRunner {
         xs
     }
 
-    pub fn output(self) -> io::Result<CommandOutput> {
-        let output = Command::new(self.program)
-            .current_dir(self.current_dir)
-            .args(self.args)
+    pub fn output(&self) -> io::Result<CommandOutput> {
+        let reified = self.execute()?;
+        let status_code = reified.status_code();
+        if 0 != status_code {
+            assert!(false, "exit({}) {:#?}", status_code, &self.args);
+        }
+        Ok(reified)
+    }
+
+    pub fn execute(&self) -> io::Result<CommandOutput> {
+        let output = Command::new(&self.program)
+            .current_dir(&self.current_dir)
+            .args(&self.args)
             .output()?;
 
         let reified = CommandOutput::new(output);
         reified.dump();
-
         Ok(reified)
     }
 }

--- a/apps/wsb-pilot/src/lib.rs
+++ b/apps/wsb-pilot/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate failure;
 
+pub mod cmd;
+
 mod error;
 pub use error::Result as PilotResult;
 

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -8,15 +8,18 @@ use wsb_pilot::{MutableSelf, PilotResult};
 fn return_zero_on_succeeded() -> PilotResult<()> {
     setup()?;
 
+    let run = |runner: CommandRunner, sample: Sample| {
+        runner
+            .arg("get-object")
+            .args(&["--bucket", &TEST_BUCKET])
+            .args(&["--key", &sample.object_key])
+            .arg(&sample.outfile_dst)
+            .output()
+    };
     let aws_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into());
-    let aws_output = aws_s3api()
-        .arg("get-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &aws_sample.object_key])
-        .arg(&aws_sample.outfile_dst)
-        .output()?;
-
+    let aws_output = run(aws_s3api(), aws_sample)?;
     dump(&aws_output);
+
     assert_eq!(
         Some(0),
         aws_output.status.code(),
@@ -35,14 +38,9 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     */
 
     let wsb_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into());
-    let wsb_output = wsb_s3api()
-        .arg("get-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &wsb_sample.object_key])
-        .arg(&wsb_sample.outfile_dst)
-        .output()?;
-
+    let wsb_output = run(wsb_s3api(), wsb_sample)?;
     dump(&wsb_output);
+
     assert_eq!(
         Some(0),
         wsb_output.status.code(),

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -42,21 +42,6 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     Ok({})
 }
 
-#[test]
-fn sample1() {
-    // setup();
-}
-
-#[test]
-fn sample2() {
-    // setup();
-}
-
-#[test]
-fn sample3() {
-    // setup();
-}
-
 // workaround to emulate singleton initializer
 lazy_static! {
     static ref WORKSPACE: PathBuf = PathBuf::new()

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -1,4 +1,4 @@
-use crate::s3api::{dump, TEST_BUCKET, TEST_WORKSPACE_DIR};
+use crate::s3api::{TEST_BUCKET, TEST_WORKSPACE_DIR};
 use serde_json::Value;
 use std::path::PathBuf;
 use wsb_pilot::cmd::CommandRunner;
@@ -18,13 +18,8 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     };
     let aws_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into());
     let aws_output = run(aws_s3api(), aws_sample)?;
-    dump(&aws_output);
-
-    assert_eq!(
-        Some(0),
-        aws_output.status.code(),
-        "return non-zero if it failed."
-    );
+    aws_output.dump();
+    assert_eq!(0, aws_output.status_code(), "return non-zero if it failed.");
 
     /*
     {
@@ -39,16 +34,11 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
 
     let wsb_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into());
     let wsb_output = run(wsb_s3api(), wsb_sample)?;
-    dump(&wsb_output);
+    wsb_output.dump();
+    assert_eq!(0, wsb_output.status_code(), "return non-zero if it failed.");
 
-    assert_eq!(
-        Some(0),
-        wsb_output.status.code(),
-        "return non-zero if it failed."
-    );
-
-    let aws_json: Value = serde_json::from_slice(&aws_output.stdout)?;
-    let wsb_json: Value = serde_json::from_slice(&wsb_output.stdout)?;
+    let aws_json: Value = serde_json::from_slice(aws_output.stdout())?;
+    let wsb_json: Value = serde_json::from_slice(wsb_output.stdout())?;
     assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
 
     Ok({})
@@ -97,7 +87,7 @@ fn init() -> PilotResult<()> {
             .args(&["--body", &mock.file_path.to_string_lossy()])
             .output()?;
 
-        dump(&aws_output);
+        aws_output.dump();
     }
     // */
     Ok({})

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -1,5 +1,4 @@
 use crate::s3api::{TEST_BUCKET, TEST_WORKSPACE_DIR};
-use serde_json::Value;
 use std::path::PathBuf;
 use wsb_pilot::cmd::CommandRunner;
 use wsb_pilot::{MutableSelf, PilotResult};
@@ -37,8 +36,8 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     wsb_output.dump();
     assert_eq!(0, wsb_output.status_code(), "return non-zero if it failed.");
 
-    let aws_json: Value = serde_json::from_slice(aws_output.stdout())?;
-    let wsb_json: Value = serde_json::from_slice(wsb_output.stdout())?;
+    let aws_json = aws_output.to_json()?;
+    let wsb_json = wsb_output.to_json()?;
     assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
 
     Ok({})

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -15,9 +15,10 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
             .arg(&sample.outfile_dst)
             .output()
     };
-    let aws_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into());
-    let aws_output = run(aws_s3api(), aws_sample)?;
-    assert_eq!(0, aws_output.status_code(), "return non-zero if it failed.");
+    let aws_output = {
+        let sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into());
+        run(aws_s3api(), sample)?
+    };
 
     /*
     {
@@ -30,10 +31,10 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     }
     */
 
-    let wsb_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into());
-    let wsb_output = run(wsb_s3api(), wsb_sample)?;
-    assert_eq!(0, wsb_output.status_code(), "return non-zero if it failed.");
-
+    let wsb_output = {
+        let sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into());
+        run(wsb_s3api(), sample)?
+    };
     let aws_json = aws_output.stdout_to_json()?;
     let wsb_json = wsb_output.stdout_to_json()?;
     assert_eq!(wsb_json["ETag"], aws_json["ETag"]);

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -57,7 +57,7 @@ fn setup() -> PilotResult<()> {
 fn init() -> PilotResult<()> {
     println!("[get-object] init");
 
-    /*
+    // /*
     for mock in get_mock_files() {
         let aws_output = aws()
             .arg("s3api")
@@ -69,7 +69,7 @@ fn init() -> PilotResult<()> {
 
         dump(&aws_output);
     }
-    */
+    // */
     Ok({})
 }
 

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -17,7 +17,6 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     };
     let aws_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into());
     let aws_output = run(aws_s3api(), aws_sample)?;
-    aws_output.dump();
     assert_eq!(0, aws_output.status_code(), "return non-zero if it failed.");
 
     /*
@@ -33,7 +32,6 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
 
     let wsb_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into());
     let wsb_output = run(wsb_s3api(), wsb_sample)?;
-    wsb_output.dump();
     assert_eq!(0, wsb_output.status_code(), "return non-zero if it failed.");
 
     let aws_json = aws_output.stdout_to_json()?;
@@ -79,14 +77,12 @@ fn init() -> PilotResult<()> {
 
     // /*
     for mock in get_mock_files() {
-        let aws_output = aws_s3api()
+        let _aws_output = aws_s3api()
             .arg("put-object")
             .args(&["--bucket", &TEST_BUCKET])
             .args(&["--key", &mock.object_key])
             .args(&["--body", &mock.file_path.to_string_lossy()])
             .output()?;
-
-        aws_output.dump();
     }
     // */
     Ok({})

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -36,8 +36,8 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
     wsb_output.dump();
     assert_eq!(0, wsb_output.status_code(), "return non-zero if it failed.");
 
-    let aws_json = aws_output.to_json()?;
-    let wsb_json = wsb_output.to_json()?;
+    let aws_json = aws_output.stdout_to_json()?;
+    let wsb_json = wsb_output.stdout_to_json()?;
     assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
 
     Ok({})

--- a/apps/wsb-pilot/tests/s3api/get_object.rs
+++ b/apps/wsb-pilot/tests/s3api/get_object.rs
@@ -1,7 +1,109 @@
-use crate::s3api::{aws, dump, s3api, TEST_BUCKET, TEST_WORKSPACE_DIR};
+use crate::s3api::{dump, TEST_BUCKET, TEST_WORKSPACE_DIR};
 use serde_json::Value;
 use std::path::PathBuf;
+use wsb_pilot::cmd::CommandRunner;
 use wsb_pilot::{MutableSelf, PilotResult};
+
+#[test]
+fn return_zero_on_succeeded() -> PilotResult<()> {
+    setup()?;
+
+    let aws_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into());
+    let aws_output = aws_s3api()
+        .arg("get-object")
+        .args(&["--bucket", &TEST_BUCKET])
+        .args(&["--key", &aws_sample.object_key])
+        .arg(&aws_sample.outfile_dst)
+        .output()?;
+
+    dump(&aws_output);
+    assert_eq!(
+        Some(0),
+        aws_output.status.code(),
+        "return non-zero if it failed."
+    );
+
+    /*
+    {
+        "AcceptRanges": "bytes",
+        "LastModified": "Thu, 20 Feb 2020 13:28:58 GMT",
+        "ContentLength": 8,
+        "ETag": "\"090a4e14a392f707cf164a20cee76c18\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {}
+    }
+    */
+
+    let wsb_sample = get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into());
+    let wsb_output = wsb_s3api()
+        .arg("get-object")
+        .args(&["--bucket", &TEST_BUCKET])
+        .args(&["--key", &wsb_sample.object_key])
+        .arg(&wsb_sample.outfile_dst)
+        .output()?;
+
+    dump(&wsb_output);
+    assert_eq!(
+        Some(0),
+        wsb_output.status.code(),
+        "return non-zero if it failed."
+    );
+
+    let aws_json: Value = serde_json::from_slice(&aws_output.stdout)?;
+    let wsb_json: Value = serde_json::from_slice(&wsb_output.stdout)?;
+    assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
+
+    Ok({})
+}
+
+#[test]
+fn sample1() {
+    // setup();
+}
+
+#[test]
+fn sample2() {
+    // setup();
+}
+
+#[test]
+fn sample3() {
+    // setup();
+}
+
+// workaround to emulate singleton initializer
+lazy_static! {
+    static ref WORKSPACE: PathBuf = PathBuf::new()
+        .join(&*TEST_WORKSPACE_DIR)
+        .join("s3api")
+        .join("get-object");
+    static ref SETUP_RESULT: PilotResult<()> = init();
+}
+
+fn setup() -> PilotResult<()> {
+    if let Err(e) = &*SETUP_RESULT {
+        assert!(false, "setup failed: {:?}", e);
+    }
+    Ok({})
+}
+
+fn init() -> PilotResult<()> {
+    println!("[get-object] init");
+
+    // /*
+    for mock in get_mock_files() {
+        let aws_output = aws_s3api()
+            .arg("put-object")
+            .args(&["--bucket", &TEST_BUCKET])
+            .args(&["--key", &mock.object_key])
+            .args(&["--body", &mock.file_path.to_string_lossy()])
+            .output()?;
+
+        dump(&aws_output);
+    }
+    // */
+    Ok({})
+}
 
 fn get_mock_files() -> Vec<MockFile> {
     vec![
@@ -27,106 +129,12 @@ fn get_sample() -> Sample {
     }
 }
 
-fn get_sample_for_aws() -> Sample {
-    get_sample().mutate(|mut x| x.outfile_dst = "./sample1.aws.tmp".into())
+fn aws_s3api() -> CommandRunner {
+    super::aws_s3api().current_dir(&*WORKSPACE)
 }
 
-fn get_sample_for_wsb() -> Sample {
-    get_sample().mutate(|mut x| x.outfile_dst = "./sample1.wsb.tmp".into())
-}
-
-// workaround to emulate singleton initializer
-lazy_static! {
-    static ref WORKSPACE: PathBuf = PathBuf::new()
-        .join(&*TEST_WORKSPACE_DIR)
-        .join("s3api")
-        .join("get-object");
-    static ref SETUP_RESULT: () = init().unwrap();
-}
-
-fn setup() -> PilotResult<()> {
-    let _ = &*SETUP_RESULT;
-    Ok({})
-}
-
-fn init() -> PilotResult<()> {
-    println!("[get-object] init");
-
-    // /*
-    for mock in get_mock_files() {
-        let aws_output = aws()
-            .current_dir(&*WORKSPACE)
-            .arg("s3api")
-            .arg("put-object")
-            .args(&["--bucket", &TEST_BUCKET])
-            .args(&["--key", &mock.object_key])
-            .args(&["--body", &mock.file_path.to_string_lossy()])
-            .output()?;
-
-        dump(&aws_output);
-    }
-    // */
-    Ok({})
-}
-
-#[test]
-fn return_zero_on_succeeded() -> PilotResult<()> {
-    setup()?;
-
-    let aws_sample = get_sample_for_aws();
-    let aws_output = aws()
-        .current_dir(&*WORKSPACE)
-        .arg("s3api")
-        .arg("get-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &aws_sample.object_key])
-        .arg(&aws_sample.outfile_dst)
-        .output()?;
-
-    dump(&aws_output);
-
-    /*
-    {
-        "AcceptRanges": "bytes",
-        "LastModified": "Thu, 20 Feb 2020 13:28:58 GMT",
-        "ContentLength": 8,
-        "ETag": "\"090a4e14a392f707cf164a20cee76c18\"",
-        "ContentType": "binary/octet-stream",
-        "Metadata": {}
-    }
-    */
-
-    let wsb_sample = get_sample_for_wsb();
-    let wsb_output = s3api()
-        .current_dir(&*WORKSPACE)
-        .arg("get-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &wsb_sample.object_key])
-        .arg(&wsb_sample.outfile_dst)
-        .output()?;
-
-    dump(&wsb_output);
-
-    let aws_json: Value = serde_json::from_slice(&aws_output.stdout)?;
-    let wsb_json: Value = serde_json::from_slice(&wsb_output.stdout)?;
-    assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
-
-    Ok({})
-}
-
-#[test]
-fn sample1() {
-    setup();
-}
-
-#[test]
-fn sample2() {
-    setup();
-}
-
-#[test]
-fn sample3() {
-    setup();
+fn wsb_s3api() -> CommandRunner {
+    super::wsb_s3api().current_dir(&*WORKSPACE)
 }
 
 struct Sample {

--- a/apps/wsb-pilot/tests/s3api/mod.rs
+++ b/apps/wsb-pilot/tests/s3api/mod.rs
@@ -18,6 +18,10 @@ fn wsb_s3api() -> CommandRunner {
     CommandRunner::new(format!("{}/s3api", *TEST_APPS_DIR))
 }
 
+fn cat() -> CommandRunner {
+    CommandRunner::new("cat")
+}
+
 fn load_test_bucket() -> FromStrResult<String> {
     SingleValue::new("WSB_TEST_BUCKET").as_required()
 }

--- a/apps/wsb-pilot/tests/s3api/mod.rs
+++ b/apps/wsb-pilot/tests/s3api/mod.rs
@@ -1,5 +1,6 @@
 use env_extractor::{FromStrResult, SingleValue};
 use std::process::{Command, Output};
+use wsb_pilot::cmd::CommandRunner;
 
 mod get_object;
 mod put_object;
@@ -10,12 +11,12 @@ lazy_static! {
     static ref TEST_WORKSPACE_DIR: String = load_workspace_dir().unwrap();
 }
 
-fn aws() -> Command {
-    Command::new("aws")
+fn aws_s3api() -> CommandRunner {
+    CommandRunner::new("aws").arg("s3api")
 }
 
-fn s3api() -> Command {
-    Command::new(format!("{}/s3api", *TEST_APPS_DIR))
+fn wsb_s3api() -> CommandRunner {
+    CommandRunner::new(format!("{}/s3api", *TEST_APPS_DIR))
 }
 
 fn load_test_bucket() -> FromStrResult<String> {

--- a/apps/wsb-pilot/tests/s3api/mod.rs
+++ b/apps/wsb-pilot/tests/s3api/mod.rs
@@ -1,5 +1,4 @@
 use env_extractor::{FromStrResult, SingleValue};
-use std::process::Output;
 use wsb_pilot::cmd::CommandRunner;
 
 mod get_object;
@@ -29,20 +28,4 @@ fn load_apps_dir() -> FromStrResult<String> {
 
 fn load_workspace_dir() -> FromStrResult<String> {
     SingleValue::new("WSB_WORKSPACE_DIR").as_required()
-}
-
-fn dump_if_failed(output: &Output) {
-    if !output.status.success() {
-        dump(output);
-    }
-}
-
-fn dump(output: &Output) {
-    let to_string = |vec| String::from_utf8_lossy(vec).to_string();
-    println!("{}", to_string(&output.stdout));
-
-    let e = to_string(&output.stderr);
-    if e.len() > 0 {
-        println!("stderr: {}", e);
-    }
 }

--- a/apps/wsb-pilot/tests/s3api/mod.rs
+++ b/apps/wsb-pilot/tests/s3api/mod.rs
@@ -1,5 +1,5 @@
 use env_extractor::{FromStrResult, SingleValue};
-use std::process::{Command, Output};
+use std::process::Output;
 use wsb_pilot::cmd::CommandRunner;
 
 mod get_object;

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -1,8 +1,6 @@
 use crate::s3api::{TEST_BUCKET, TEST_WORKSPACE_DIR};
-use serde_json::Value;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use wsb_pilot::cmd::CommandRunner;
 use wsb_pilot::PilotResult;
 
@@ -36,13 +34,8 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
 
 fn read_to_string(path: &Path) -> io::Result<String> {
     let path_str: &str = &path.to_string_lossy();
-    let output = Command::new("cat")
-        .current_dir(&*WORKSPACE)
-        .arg(path_str)
-        .output()?;
-
-    let output_str = String::from_utf8_lossy(&output.stdout).to_string();
-    Ok(output_str)
+    let output = cat().arg(path_str).output()?;
+    Ok(output.to_stdout_string())
 }
 
 #[test]
@@ -99,6 +92,10 @@ fn aws_s3api() -> CommandRunner {
 
 fn wsb_s3api() -> CommandRunner {
     super::wsb_s3api().current_dir(&*WORKSPACE)
+}
+
+fn cat() -> CommandRunner {
+    super::cat().current_dir(&*WORKSPACE)
 }
 
 struct Sample {

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -7,20 +7,26 @@ use wsb_pilot::PilotResult;
 #[test]
 fn return_zero_on_succeeded() -> PilotResult<()> {
     let sample = get_sample1();
-
-    let _wsb_output = wsb_s3api()
-        .arg("put-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &sample.object_key])
-        .args(&["--body", &sample.upload_src.to_string_lossy()])
-        .output()?;
-
-    let expected = read_to_string(&sample.upload_src)?;
+    let expected = {
+        upload(&sample)?;
+        read_to_string(&sample.upload_src)?
+    };
     let actual = {
         download(&sample)?;
         read_to_string(&sample.download_dst)?
     };
     assert_eq!(actual, expected, "correctly uploaded.");
+    Ok({})
+}
+
+fn upload(target: &Sample) -> PilotResult<()> {
+    wsb_s3api()
+        .arg("put-object")
+        .args(&["--bucket", &TEST_BUCKET])
+        .args(&["--key", &target.object_key])
+        .args(&["--body", &target.upload_src.to_string_lossy()])
+        .output()?;
+
     Ok({})
 }
 

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -52,22 +52,18 @@ fn read_to_string(path: &Path) -> io::Result<String> {
 #[test]
 fn output_e_tag_is_correct() -> PilotResult<()> {
     let sample = get_sample1();
-    let aws_output = aws_s3api()
-        .arg("put-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &sample.object_key])
-        .args(&["--body", &sample.upload_src.to_string_lossy()])
-        .output()?;
-
+    let run = |runner: CommandRunner| {
+        runner
+            .arg("put-object")
+            .args(&["--bucket", &TEST_BUCKET])
+            .args(&["--key", &sample.object_key])
+            .args(&["--body", &sample.upload_src.to_string_lossy()])
+            .output()
+    };
+    let aws_output = run(aws_s3api())?;
     dump_if_failed(&aws_output);
 
-    let wsb_output = wsb_s3api()
-        .arg("put-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &sample.object_key])
-        .args(&["--body", &sample.upload_src.to_string_lossy()])
-        .output()?;
-
+    let wsb_output = run(wsb_s3api())?;
     dump(&wsb_output);
 
     let aws_json: Value = serde_json::from_slice(&aws_output.stdout)?;

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -35,7 +35,7 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
 fn read_to_string(path: &Path) -> io::Result<String> {
     let path_str: &str = &path.to_string_lossy();
     let output = cat().arg(path_str).output()?;
-    Ok(output.to_stdout_string())
+    Ok(output.stdout_to_string())
 }
 
 #[test]
@@ -55,8 +55,8 @@ fn output_e_tag_is_correct() -> PilotResult<()> {
     let wsb_output = run(wsb_s3api())?;
     wsb_output.dump();
 
-    let aws_json = aws_output.to_json()?;
-    let wsb_json = wsb_output.to_json()?;
+    let aws_json = aws_output.stdout_to_json()?;
+    let wsb_json = wsb_output.stdout_to_json()?;
     assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
 
     Ok({})

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -8,14 +8,12 @@ use wsb_pilot::PilotResult;
 fn return_zero_on_succeeded() -> PilotResult<()> {
     let sample = get_sample1();
 
-    let wsb_output = wsb_s3api()
+    let _wsb_output = wsb_s3api()
         .arg("put-object")
         .args(&["--bucket", &TEST_BUCKET])
         .args(&["--key", &sample.object_key])
         .args(&["--body", &sample.upload_src.to_string_lossy()])
         .output()?;
-
-    assert_eq!(0, wsb_output.status_code(), "return non-zero if it failed.");
 
     let expected = read_to_string(&sample.upload_src)?;
     let actual = {
@@ -69,7 +67,7 @@ fn output_e_tag_is_correct() -> PilotResult<()> {
 
 #[test]
 fn return_non_zero_on_failed() -> PilotResult<()> {
-    let output = wsb_s3api().arg("unknown-subcommand").output()?;
+    let output = wsb_s3api().arg("unknown-subcommand").execute()?;
     assert_eq!(1, output.status_code(), "return zero if it succeeded.");
     Ok({})
 }

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -6,6 +6,14 @@ use wsb_pilot::PilotResult;
 
 #[test]
 fn return_zero_on_succeeded() -> PilotResult<()> {
+    let upload = |target: &Sample| {
+        wsb_s3api()
+            .arg("put-object")
+            .args(&["--bucket", &TEST_BUCKET])
+            .args(&["--key", &target.object_key])
+            .args(&["--body", &target.upload_src.to_string_lossy()])
+            .output()
+    };
     let sample = get_sample1();
     let expected = {
         upload(&sample)?;
@@ -16,17 +24,6 @@ fn return_zero_on_succeeded() -> PilotResult<()> {
         read_to_string(&sample.download_dst)?
     };
     assert_eq!(actual, expected, "correctly uploaded.");
-    Ok({})
-}
-
-fn upload(target: &Sample) -> PilotResult<()> {
-    wsb_s3api()
-        .arg("put-object")
-        .args(&["--bucket", &TEST_BUCKET])
-        .args(&["--key", &target.object_key])
-        .args(&["--body", &target.upload_src.to_string_lossy()])
-        .output()?;
-
     Ok({})
 }
 

--- a/apps/wsb-pilot/tests/s3api/put_object.rs
+++ b/apps/wsb-pilot/tests/s3api/put_object.rs
@@ -62,8 +62,8 @@ fn output_e_tag_is_correct() -> PilotResult<()> {
     let wsb_output = run(wsb_s3api())?;
     wsb_output.dump();
 
-    let aws_json: Value = serde_json::from_slice(aws_output.stdout())?;
-    let wsb_json: Value = serde_json::from_slice(wsb_output.stdout())?;
+    let aws_json = aws_output.to_json()?;
+    let wsb_json = wsb_output.to_json()?;
     assert_eq!(wsb_json["ETag"], aws_json["ETag"]);
 
     Ok({})

--- a/libs/aws/sabi-s3/src/actions/put_object/mod.rs
+++ b/libs/aws/sabi-s3/src/actions/put_object/mod.rs
@@ -9,7 +9,7 @@ pub use rich_file::RichFile;
 
 use crate::actions::put_object;
 use crate::client::S3Client;
-use crate::core::verbs::{HasObjectKey, IsPost};
+use crate::core::verbs::{HasObjectKey, IsPut};
 use crate::core::{ETag, S3HeaderMap};
 use crate::internal::{InternalClient, RequestProvider, ResourceLoader};
 use crate::{actions, core, internal};
@@ -29,7 +29,7 @@ pub struct Headers {
     pub e_tag: ETag,
 }
 
-impl<A: Request> IsPost<Response> for A {}
+impl<A: Request> IsPut<Response> for A {}
 
 pub trait Requester {
     fn put_object<A>(&self, request: A) -> actions::Result<Response>

--- a/libs/aws/sabi-s3/src/core/verbs/has_method.rs
+++ b/libs/aws/sabi-s3/src/core/verbs/has_method.rs
@@ -13,10 +13,10 @@ impl<A, B: IsGet<A>> HasMethod<GetImpl<A>> for B {
     const METHOD: Method = Method::GET;
 }
 
-pub struct PostImpl<A>(PhantomData<A>);
+pub struct PutImpl<A>(PhantomData<A>);
 
-pub trait IsPost<MARKER> {}
+pub trait IsPut<MARKER> {}
 
-impl<A, B: IsPost<A>> HasMethod<PostImpl<A>> for B {
-    const METHOD: Method = Method::POST;
+impl<A, B: IsPut<A>> HasMethod<PutImpl<A>> for B {
+    const METHOD: Method = Method::PUT;
 }

--- a/libs/aws/sabi-s3/src/core/verbs/mod.rs
+++ b/libs/aws/sabi-s3/src/core/verbs/mod.rs
@@ -10,4 +10,4 @@ pub use has_bucket_scope::HasBucketScope;
 mod has_method;
 pub use has_method::HasMethod;
 pub use has_method::IsGet;
-pub use has_method::IsPost;
+pub use has_method::IsPut;

--- a/scripts/run_pilot.sh
+++ b/scripts/run_pilot.sh
@@ -9,7 +9,13 @@
 #   $ ./scripts/run_pilot.sh
 #
 # Enable to print stdout if necessary:
-#   $ ./scripts/run_pilot.sh --nocapture
+#   $ ./scripts/run_pilot.sh --color always --nocapture
+#
+# Disable to run in parallel:
+#   $ ./scripts/run_pilot.sh --color always --test-threads=1
+#
+# See also:
+#   https://doc.rust-lang.org/book/ch11-02-running-tests.html
 
 
 # stop if non-zero returned.


### PR DESCRIPTION

* [x] add modules to wrap built-in `std::process::(Command|Output)`
* [x] remove many duplicates. (especially around `dump` and `go_to_workspace`)
* [x] bugfix: `put_object` action needs PUT method, not POST :innocent: 
